### PR TITLE
Add torch 0.17 / libtorch 2.8 compatibility

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,8 +26,8 @@ jobs:
           - {runner: [self-hosted, m1],    r_version: '',      os: macOS}
           - {runner: windows-2019,         r_version: release, os: windows}
           - {runner: ubuntu-latest,        r_version: release, os: ubuntu}
-          - {runner: [self-hosted, linux], r_version: release, os: ubuntu, cuda: 11.8, cuda_patch: 0}
-          - {runner: windows-2019,         r_version: release, os: windows, cuda: 11.8, cuda_patch: 0}
+          - {runner: [self-hosted, linux], r_version: release, os: ubuntu, cuda: 12.6, cuda_patch: 0}
+          - {runner: windows-2019,         r_version: release, os: windows, cuda: 12.6, cuda_patch: 0}
 
         include:
           - config: {os: ubuntu}
@@ -63,7 +63,7 @@ jobs:
           cmake-version: '3.31'
 
       - if: ${{matrix.config.cuda != ''}}
-        uses: Jimver/cuda-toolkit@v0.2.21
+        uses: Jimver/cuda-toolkit@v0.2.23
         id: cuda-toolkit
         with:
           cuda: '${{matrix.config.cuda}}.${{matrix.config.cuda_patch}}'
@@ -90,8 +90,8 @@ jobs:
         run: |
           version=$(Rscript -e "cat(as.character(desc::desc_get_version()))")
           fname=$(Rscript -e "cat(list.files('csrc/build/', '*.zip'))")
-          echo "::set-output name=version::$version"
-          echo "::set-output name=fname::$fname"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "fname=$fname" >> $GITHUB_OUTPUT
 
       - uses: svenstaro/upload-release-action@v2
         if: github.ref_name == 'main'
@@ -154,7 +154,7 @@ jobs:
         id: version
         run: |
           version=$(Rscript -e "cat(as.character(desc::desc_get_version()))")
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v4
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: torchvisionlib
 Title: Additional Operators for Image Models
-Version: 0.6.0
+Version: 0.7.0
 Authors@R: c(
     person("Daniel", "Falbel", , "daniel@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))
@@ -19,7 +19,7 @@ LinkingTo:
     torch
 Imports: 
     Rcpp,
-    torch (>= 0.14.0),
+    torch (>= 0.17.0),
     rlang,
     glue,
     withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # torchvisionlib (development version)
 
+# torchvisionlib 0.7.0
+
+- Updates to support LibTorch v2.8
+
+
 # torchvisionlib 0.5.0
 
 - Updates to support LibTorch v2.0.1

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 message(STATUS "CMAKE_ARGS: ${TORCHVISION_CMAKE_ARGS}")
 ExternalProject_Add(TorchVision-project
   GIT_REPOSITORY https://github.com/pytorch/vision
-  GIT_TAG v0.20.1
+  GIT_TAG v0.23.0
   DEPENDS ${TORCHVISION_DEPENDS}
   CMAKE_CACHE_ARGS ${TORCHVISION_CMAKE_ARGS}
   PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libtorchvision"

--- a/csrc/patch/kuint16.patch
+++ b/csrc/patch/kuint16.patch
@@ -1,23 +1,3 @@
-diff --git a/torchvision/csrc/io/image/cpu/decode_png.cpp b/torchvision/csrc/io/image/cpu/decode_png.cpp
-index ede14c1e94..a42bd06c35 100644
---- a/torchvision/csrc/io/image/cpu/decode_png.cpp
-+++ b/torchvision/csrc/io/image/cpu/decode_png.cpp
-@@ -195,9 +195,13 @@ torch::Tensor decode_png(
- 
-   auto num_pixels_per_row = width * channels;
-   auto is_16_bits = bit_depth == 16;
-+
-+  if (is_16_bits) {
-+    throw std::runtime_error("16-bit PNG images are not supported.");
-+  }
-+
-   auto tensor = torch::empty(
--      {int64_t(height), int64_t(width), channels},
--      is_16_bits ? at::kUInt16 : torch::kU8);
-+      {int64_t(height), int64_t(width), channels}, torch::kU8);
-   if (is_little_endian()) {
-     png_set_swap(png_ptr);
-   }
 diff --git a/torchvision/csrc/ops/nms.cpp b/torchvision/csrc/ops/nms.cpp
 index 5ecf8812f1..2cbbe93873 100644
 --- a/torchvision/csrc/ops/nms.cpp


### PR DESCRIPTION
Closes #27

Updated `torchvisionlib` to work with `{torch} 0.17` (libtorch 2.8) by aligning with the corresponding `pytorch/vision` version.

Changes:

* Updated `GIT_TAG` to `v0.23.0` in `CMakeLists.txt`
* Removed the `decode_png` patch since 16-bit PNG support is now available upstream
* Updated CI to use CUDA 12.6 instead of 11.8
* Fixed deprecated `::set-output` usage in GitHub Actions
* Bumped package version to 0.7.0


